### PR TITLE
Schedule pipeline and fix original tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-04-29T16:40:24Z",
+  "generated_at": "2020-04-29T16:57:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -48,7 +48,7 @@
   "results": {
     "Pipfile.lock": [
       {
-        "hashed_secret": "3e7f85fdfda2626b1c67d8b099fcdfb06457b4ff",
+        "hashed_secret": "165096d0d937b6dd43bab1882168ed7541290422",
         "is_secret": false,
         "is_verified": false,
         "line_number": 4,

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": null,
+    "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-04-29T10:07:21Z",
+  "generated_at": "2020-04-29T16:40:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -60,14 +60,14 @@
         "hashed_secret": "9ee8406f67b1365f321948f8caeeabf0a2de5610",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 62,
+        "line_number": 71,
         "type": "AWS Access Key"
       },
       {
         "hashed_secret": "52a00b8461593ce33409d7c5d0411699cbf9cda3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 72,
         "type": "Secret Keyword"
       }
     ],
@@ -80,70 +80,12 @@
         "type": "Secret Keyword"
       }
     ],
-    "tests/fixtures/cassettes/test_download_report.yaml": [
-      {
-        "hashed_secret": "68601682b2fd669497bb289344093a632810ff19",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 20,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "7eb7a5c09ba11338ad2f918fc0634d059a66954b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 21,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "a7054db135f705dc31d6b7dff662a281a85321f4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "9d24ec463742a4b7d8ac15df8a2732b1c20733ad",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "626b67a1f0c91e7b17af278fdff8acace55041d8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 24,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "ab97f9b27dd4f25e6e9b1464d22944aed698aa60",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 25,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "901e1c9d23b7d9e5094aefd74704780fee6a4fa3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 26,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "d4d8c39b1e84b207721bc7c8e34807235ccd7eb4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 27,
-        "type": "Base64 High Entropy String"
-      }
-    ],
     "tests/test_nessus.py": [
       {
-        "hashed_secret": "cf500d9702acdc500f5220bafafa5a8ba21d9ff9",
+        "hashed_secret": "6dbf3cc33ec74b1e38907833100905c13048af2a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 87,
+        "line_number": 78,
         "type": "Hex High Entropy String"
       }
     ]

--- a/Pipfile
+++ b/Pipfile
@@ -5,15 +5,15 @@ verify_ssl = true
 
 [dev-packages]
 black = "*"
-
-[packages]
-requests = "*"
-boto3 = "*"
 mypy-boto3 = "*"
 mypy-boto3-logs = "*"
 boto3-stubs = {extras = ["logs"],version = "*"}
 pytest = "*"
 pytest-mock = "*"
+
+[packages]
+requests = "*"
+boto3 = "*"
 vcrpy = "*"
 toml = "*"
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9cd4347467e771e57f87f362988452ff7597543ccef682b4ee8d9496eaa798c2"
+            "sha256": "06d6c6a721cbea7bc9136da002bf5d628e788c1057729dcaddf49f21ac2a3d9e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -40,28 +40,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:7f8b822e383c0d7656488d3b6fdc3e9c42a56fab3ed1a27c2cbc65876093cb21",
-                "sha256:84daba6d2f0c8d55477ba0b8196ffa7eb7f79d9099f768ac93eb968955877a3f"
+                "sha256:39ef75f1351d9dce9542c71602bbe4dbae001df1aa5c75bdacea933d60cc1e7f",
+                "sha256:d345f2ba820f022ab45627913cb427b1fa56d7c1f8e19312eee20874ba800007"
             ],
             "index": "pypi",
-            "version": "==1.12.47"
-        },
-        "boto3-stubs": {
-            "extras": [
-                "logs"
-            ],
-            "hashes": [
-                "sha256:46957c018b8c77f142fbc922b2b45b37dae3c982d9b7a21802d2b4fe4b226a5f"
-            ],
-            "index": "pypi",
-            "version": "==1.12.47.0"
+            "version": "==1.12.48"
         },
         "botocore": {
             "hashes": [
-                "sha256:6c6e9db7a6e420431794faee111923e4627b4920d4d9d8b16e1a578a389b2283",
-                "sha256:cceeb6d2a1bbbd062ab54552ded5065a12b14e845aa35613fc91fd68312020c0"
+                "sha256:ef4fa3055421cb95a7bf559e715f8c5f656aca30fafef070eca21b13ca3f0f81",
+                "sha256:f3569216d2f0067a34608e26ae1d0035b84fa29ad68d6c5fd26124a4cc86e8c9"
             ],
-            "version": "==1.15.47"
+            "version": "==1.15.48"
         },
         "certifi": {
             "hashes": [
@@ -106,13 +96,6 @@
             ],
             "version": "==0.9.5"
         },
-        "more-itertools": {
-            "hashes": [
-                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
-                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
-            ],
-            "version": "==8.2.0"
-        },
         "multidict": {
             "hashes": [
                 "sha256:317f96bc0950d249e96d8d29ab556d01dd38888fbe68324f46fd834b430169f1",
@@ -135,70 +118,12 @@
             ],
             "version": "==4.7.5"
         },
-        "mypy-boto3": {
-            "hashes": [
-                "sha256:94e76a452fef71ffa9495fc75c2953b83fa79c92808b70f38c5098bf0d56c22b"
-            ],
-            "index": "pypi",
-            "version": "==1.12.47.0"
-        },
-        "mypy-boto3-logs": {
-            "hashes": [
-                "sha256:6a4b6a893463d5a97aecbc57e51c5d69367378d9c2813325591215fd11febb08"
-            ],
-            "index": "pypi",
-            "version": "==1.12.47.0"
-        },
-        "packaging": {
-            "hashes": [
-                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
-                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
-            ],
-            "version": "==20.3"
-        },
         "pathspec": {
             "hashes": [
                 "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0",
                 "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"
             ],
             "version": "==0.8.0"
-        },
-        "pluggy": {
-            "hashes": [
-                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
-                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
-            ],
-            "version": "==0.13.1"
-        },
-        "py": {
-            "hashes": [
-                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
-                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
-            ],
-            "version": "==1.8.1"
-        },
-        "pyparsing": {
-            "hashes": [
-                "sha256:67199f0c41a9c702154efb0e7a8cc08accf830eb003b4d9fa42c4059002e2492",
-                "sha256:700d17888d441604b0bd51535908dcb297561b040819cccde647a92439db5a2a"
-            ],
-            "version": "==3.0.0a1"
-        },
-        "pytest": {
-            "hashes": [
-                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
-                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
-            ],
-            "index": "pypi",
-            "version": "==5.4.1"
-        },
-        "pytest-mock": {
-            "hashes": [
-                "sha256:997729451dfc36b851a9accf675488c7020beccda15e11c75632ee3d1b1ccd71",
-                "sha256:ce610831cedeff5331f4e2fc453a5dd65384303f680ab34bee2c6533855b431c"
-            ],
-            "index": "pypi",
-            "version": "==3.1.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -321,13 +246,6 @@
             "index": "pypi",
             "version": "==4.0.2"
         },
-        "wcwidth": {
-            "hashes": [
-                "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
-                "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
-            ],
-            "version": "==0.1.9"
-        },
         "wrapt": {
             "hashes": [
                 "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
@@ -381,6 +299,31 @@
             "index": "pypi",
             "version": "==19.10b0"
         },
+        "boto3": {
+            "hashes": [
+                "sha256:39ef75f1351d9dce9542c71602bbe4dbae001df1aa5c75bdacea933d60cc1e7f",
+                "sha256:d345f2ba820f022ab45627913cb427b1fa56d7c1f8e19312eee20874ba800007"
+            ],
+            "index": "pypi",
+            "version": "==1.12.48"
+        },
+        "boto3-stubs": {
+            "extras": [
+                "logs"
+            ],
+            "hashes": [
+                "sha256:71b65a46cb818364353e5742f1fe38734ec0bc4801b67a81a0d0903a2197116e"
+            ],
+            "index": "pypi",
+            "version": "==1.12.48.0"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:ef4fa3055421cb95a7bf559e715f8c5f656aca30fafef070eca21b13ca3f0f81",
+                "sha256:f3569216d2f0067a34608e26ae1d0035b84fa29ad68d6c5fd26124a4cc86e8c9"
+            ],
+            "version": "==1.15.48"
+        },
         "click": {
             "hashes": [
                 "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
@@ -388,12 +331,107 @@
             ],
             "version": "==7.1.2"
         },
+        "docutils": {
+            "hashes": [
+                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
+                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
+                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
+            ],
+            "version": "==0.15.2"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
+                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==1.6.0"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:695cb76fa78a10663425d5b73ddc5714eb711157e52704d69be03b1a02ba4fec",
+                "sha256:cca55c8d153173e21baa59983015ad0daf603f9cb799904ff057bfb8ff8dc2d9"
+            ],
+            "version": "==0.9.5"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
+                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
+            ],
+            "version": "==8.2.0"
+        },
+        "mypy-boto3": {
+            "hashes": [
+                "sha256:85be2ccabe6f646191b9dab6d7bbdfb3761eafced0843e27922bdca5dab2b61a"
+            ],
+            "index": "pypi",
+            "version": "==1.12.48.0"
+        },
+        "mypy-boto3-logs": {
+            "hashes": [
+                "sha256:372dbca96ed934035c90ae6eb0c33bfd2a74ff8a7ea5b81d6a19dc13769be4b5"
+            ],
+            "index": "pypi",
+            "version": "==1.12.48.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
+                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+            ],
+            "version": "==20.3"
+        },
         "pathspec": {
             "hashes": [
                 "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0",
                 "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"
             ],
             "version": "==0.8.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
+                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
+            ],
+            "version": "==1.8.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:67199f0c41a9c702154efb0e7a8cc08accf830eb003b4d9fa42c4059002e2492",
+                "sha256:700d17888d441604b0bd51535908dcb297561b040819cccde647a92439db5a2a"
+            ],
+            "version": "==3.0.0a1"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
+                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+            ],
+            "index": "pypi",
+            "version": "==5.4.1"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:997729451dfc36b851a9accf675488c7020beccda15e11c75632ee3d1b1ccd71",
+                "sha256:ce610831cedeff5331f4e2fc453a5dd65384303f680ab34bee2c6533855b431c"
+            ],
+            "index": "pypi",
+            "version": "==3.1.0"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "version": "==2.8.1"
         },
         "regex": {
             "hashes": [
@@ -420,6 +458,20 @@
                 "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"
             ],
             "version": "==2020.4.4"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13",
+                "sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db"
+            ],
+            "version": "==0.3.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
         },
         "toml": {
             "hashes": [
@@ -454,6 +506,36 @@
                 "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
             ],
             "version": "==1.4.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5",
+                "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae",
+                "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"
+            ],
+            "version": "==3.7.4.2"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
+                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+            ],
+            "markers": "python_version != '3.4'",
+            "version": "==1.25.9"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
+                "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
+            ],
+            "version": "==0.1.9"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
+                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
+            ],
+            "version": "==3.1.0"
         }
     }
 }

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -16,6 +16,15 @@ resources:
       uri: https://github.com/alphagov/cyber-security-nessus.git
       branch: master
 
+  - name: toml-nessus-git
+    icon: github-circle
+    type: git
+    source:
+      uri: https://github.com/alphagov/cyber-security-nessus.git
+      branch: master
+      paths:
+        - scan_config/scan.toml
+
   - name: health-notification
     type: http-api
     source:
@@ -67,12 +76,12 @@ jobs:
         on_success:
           <<: *health_status_notify
           params:
-            message: "Nessus instance built successfully."
+            message: "Nessus python tests passed."
             health: healthy
         on_failure:
           <<: *health_status_notify
           params:
-            message: "Failed to build Nessus instance"
+            message: "Nessus python tests failed"
             health: unhealthy
 
   - name: terraform_validation
@@ -99,12 +108,12 @@ jobs:
         on_success:
           <<: *health_status_notify
           params:
-            message: "Nessus instance built successfully."
+            message: "Nessus terraform validated."
             health: healthy
         on_failure:
           <<: *health_status_notify
           params:
-            message: "Failed to build Nessus instance"
+            message: "Failed to validate nessus terraform."
             health: unhealthy
 
   - name: nessus_deploy
@@ -143,10 +152,48 @@ jobs:
         on_success:
           <<: *health_status_notify
           params:
-            message: "Nessus instance built successfully."
+            message: "Nessus deployed successfully."
             health: healthy
         on_failure:
           <<: *health_status_notify
           params:
-            message: "Failed to build Nessus instance"
+            message: "Failed to deploy nessus."
+            health: unhealthy
+
+  - name: schedule_scans_update
+    serial: false
+    plan:
+      - get: toml-nessus-git
+        trigger: true
+      - task: update_scheduled_scans
+        config:
+          inputs:
+          - name: toml-nessus-git
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: gdscyber/cyber-security-concourse-base-image
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                pip install pipenv
+
+                cd toml-nessus-git
+                pipenv --python 3.7
+                pipenv install
+
+                source /usr/local/bin/sts-assume-role.sh 'arn:aws:iam::676218256630:role/nessus_role' 'eu-west-2'
+                pipenv run python schedule_scans.py
+        on_success:
+          <<: *health_status_notify
+          params:
+            message: "Nessus has scheduled new scans."
+            health: healthy
+        on_failure:
+          <<: *health_status_notify
+          params:
+            message: "Failed to schedule new scans."
             health: unhealthy

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -14,7 +14,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/cyber-security-nessus.git
-      branch: schedule-pipeline-and-tests
+      branch: master
 
   - name: toml-nessus-git
     icon: github-circle

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -165,6 +165,9 @@ jobs:
     plan:
       - get: toml-nessus-git
         trigger: true
+      - get: cyber-security-nessus-git
+        passed: [nessus_deploy]
+        trigger: true
       - task: update_scheduled_scans
         config:
           inputs:

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -14,7 +14,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/cyber-security-nessus.git
-      branch: master
+      branch: schedule-pipeline-and-tests
 
   - name: toml-nessus-git
     icon: github-circle
@@ -48,7 +48,7 @@ jobs:
     plan:
       - get: cyber-security-nessus-git
         trigger: true
-      - task: run-lambda-formatting-validation
+      - task: run-lambda-validation
         config:
           inputs:
           - name: cyber-security-nessus-git
@@ -65,7 +65,7 @@ jobs:
                 pip install pipenv
                 cd cyber-security-nessus-git
                 pipenv --python 3.7
-                pipenv install
+                pipenv install --dev
 
                 # These are needed to prevent the tests from contacting the AWS magic HTTP server.
                 export AWS_ACCESS_KEY_ID=AKIA00AA00AAAA0A0AAA

--- a/tests/fixtures/cassettes/test_api_credentials.yaml
+++ b/tests/fixtures/cassettes/test_api_credentials.yaml
@@ -39,4 +39,44 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: '{"Name": "/nessus/secret_key", "WithDecryption": true}'
+    headers:
+      Authorization:
+      - !!binary |
+        ===
+      Content-Length:
+      - '54'
+      Content-Type:
+      - !!binary |
+        ===
+      User-Agent:
+      - !!binary |
+        ===
+      X-Amz-Date:
+      - !!binary |
+        ===
+      X-Amz-Security-Token:
+      - !!binary |
+        ===
+      X-Amz-Target:
+      - !!binary |
+        ===
+    method: POST
+    uri: https://ssm.eu-west-2.amazonaws.com/
+  response:
+    body:
+      string: '{"Parameter":{"ARN":"arn:aws:ssm:eu-west-2:000000000:parameter/nessus/secret_key","DataType":"text","LastModifiedDate":1.587738359607E9,"Name":"/nessus/secret_key","Type":"SecureString","Value":"SECRET_KEY","Version":3}}'
+    headers:
+      Content-Length:
+      - '277'
+      Content-Type:
+      - application/x-amz-json-1.1
+      Date:
+      - Fri, 24 Apr 2020 15:32:17 GMT
+      x-amzn-RequestId:
+      - c5
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/test_download_report.yaml
+++ b/tests/fixtures/cassettes/test_download_report.yaml
@@ -1,5 +1,33 @@
 interactions:
 - request:
+    body: '{"Name": "/nessus/public_base_url", "WithDecryption": true}'
+    headers:
+      Content-Length:
+      - '59'
+      Content-Type:
+      - !!binary |
+        YXBwbGljYXRpb24veC1hbXotanNvbi0xLjE=
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS4xMi40NyBQeXRob24vMy43LjQgRGFyd2luLzE4LjcuMCBCb3RvY29yZS8xLjE1LjQ3
+    method: POST
+    uri: https://ssm.eu-west-2.amazonaws.com/
+  response:
+    body:
+      string: '{"Parameter":{"ARN":"arn:aws:ssm:eu-west-2:000000000:parameter/nessus/public_base_url","DataType":"text","LastModifiedDate":1.588155648471E9,"Name":"/nessus/public_base_url","Type":"SecureString","Value":"https://localhost:8834","Version":64}}'
+    headers:
+      Content-Length:
+      - '250'
+      Content-Type:
+      - application/x-amz-json-1.1
+      Date:
+      - Wed, 29 Apr 2020 15:40:02 GMT
+      x-amzn-RequestId:
+      - da354713-955e-4f51-864c-2399d0b3fcf1
+    status:
+      code: 200
+      message: OK
+- request:
     body: null
     headers:
       Accept:
@@ -9,9 +37,9 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.22.0
+      - python-requests/2.23.0
       X-ApiKeys:
-      - accessKey=FOO; secretKey=BAR
+      - accessKey=ACCESS_KEY; secretKey=SECRET_KEY
     method: GET
     uri: https://localhost:8834/tokens/TOKEN/download
   response:
@@ -30,19 +58,17 @@ interactions:
       - no-cache, no-store, must-revalidate
       Connection:
       - close
-      Content-Disposition:
-      - attachment; filename="govuk_zadbsp.csv"
-      Content-Encoding:
-      - gzip
+      Content-Length:
+      - '44'
       Content-Security-Policy:
       - upgrade-insecure-requests; block-all-mixed-content; form-action 'self'; frame-ancestors
         'none'; frame-src https://store.tenable.com; default-src 'self'; script-src
         'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; object-src
         'none'
       Content-Type:
-      - text/csv
+      - application/json
       Date:
-      - Mon, 27 Apr 2020 10:29:10 GMT
+      - Wed, 29 Apr 2020 15:40:03 GMT
       Expect-CT:
       - max-age=0
       Expires:
@@ -53,8 +79,6 @@ interactions:
       - NessusWWW
       Strict-Transport-Security:
       - max-age=31536000
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:

--- a/tests/fixtures/cassettes/test_prepare_export.yaml
+++ b/tests/fixtures/cassettes/test_prepare_export.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: format=csv
+    body: '{"format": "csv"}'
     headers:
       Accept:
       - '*/*'
@@ -15,8 +15,7 @@ interactions:
       User-Agent:
       - python-requests/2.22.0
       X-ApiKeys:
-      - accessKey=FOO;
-        secretKey=BAR
+      - accessKey=FOO; secretKey=BAR
     method: POST
     uri: https://localhost:8834/scans/5/export
   response:
@@ -54,6 +53,34 @@ interactions:
       - DENY
       X-XSS-Protection:
       - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"Name": "/nessus/public_base_url", "WithDecryption": true}'
+    headers:
+      Content-Length:
+      - '59'
+      Content-Type:
+      - !!binary |
+        YXBwbGljYXRpb24veC1hbXotanNvbi0xLjE=
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS4xMi40NyBQeXRob24vMy43LjQgRGFyd2luLzE4LjcuMCBCb3RvY29yZS8xLjE1LjQ3
+    method: POST
+    uri: https://ssm.eu-west-2.amazonaws.com/
+  response:
+    body:
+      string: '{"Parameter":{"ARN":"arn:aws:ssm:eu-west-2:000000000000:parameter/nessus/public_base_url","DataType":"text","LastModifiedDate":1.588155648471E9,"Name":"/nessus/public_base_url","Type":"SecureString","Value":"https://localhost:8834","Version":64}}'
+    headers:
+      Content-Length:
+      - '250'
+      Content-Type:
+      - application/x-amz-json-1.1
+      Date:
+      - Wed, 29 Apr 2020 16:12:51 GMT
+      x-amzn-RequestId:
+      - 4e9e9710-8225-43cd-8ead-a328565ccd5b
     status:
       code: 200
       message: OK


### PR DESCRIPTION
Closes #12 

This is a WIP for the pipeline to to schedule scans.

It is mostly done in that it will schedule them in using our python code.

One thing that still needs to be done is make sure that it only runs once. At the moment if there are changes to master, the whole pipeline will run schedule_scans.py but if there are changes to master and to the toml file, it will run once and then again when deployed (creating double the amount of scans).

We also have to implement a few more tests, this could be done here or in another task. We have fixed the unit tests to fit with our newly refactored code. One thing to keep in mind for future reference is when installing pytest with pipenv, we must ensure we use `pipenv install -d pytest` to add it to the `dev-packages` section and then when we want to run the unit tests in concourse, we should run `pipenv install --dev` to install all our dev dependencies as well as the standard ones. (This is all due to a weird dependency in pytest that is only available from python 3.8.