### PR TITLE
Process scans daily, not on build

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-05-28T10:45:24Z",
+  "generated_at": "2020-05-28T14:35:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -60,14 +60,14 @@
         "hashed_secret": "9ee8406f67b1365f321948f8caeeabf0a2de5610",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 71,
+        "line_number": 80,
         "type": "AWS Access Key"
       },
       {
         "hashed_secret": "52a00b8461593ce33409d7c5d0411699cbf9cda3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 72,
+        "line_number": 81,
         "type": "Secret Keyword"
       }
     ],

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -41,6 +41,15 @@ resources:
         build_number: "{BUILD_NAME}"
       service: "Nessus Pipeline"
 
+  - name: every-weekday-resource
+    type: time
+    icon: clock-outline
+    source:
+      start: 10:00 AM
+      stop: 4:00 PM
+      location: Europe/London
+      interval: 24h
+      days: [Monday, Tuesday, Wednesday, Thursday, Friday]
 
 jobs:
   - name: python_validation
@@ -253,7 +262,7 @@ jobs:
     serial: false
     plan:
       - get: cyber-security-nessus-git
-        passed: [schedule_scans_update]
+      - get: every-weekday-resource
         trigger: true
       - task: process_scans
         config:


### PR DESCRIPTION
When I was checking if the health notifications was working again, I noticed Alex and I forgot to switch the pipeline to run `process_scans` once a day on a schedule. We had it running on every build which is next to useless but we did when we were getting it working for the first time. This has already been pushed with fly.