### PR TITLE
Check if list policies returns none before finding

### DIFF
--- a/nessus.py
+++ b/nessus.py
@@ -115,6 +115,11 @@ def base_url():
 
 
 def list_policies():
+    """
+    The nessus API changed and appeared to return:
+    {'policies': None} instead of {'policies': []},
+    breaking gds_scan_policy_id().
+    """
     policies = get("/policies")
     if policies["policies"] is None:
         policies["policies"] = []

--- a/nessus.py
+++ b/nessus.py
@@ -115,7 +115,10 @@ def base_url():
 
 
 def list_policies():
-    return get("/policies")
+    policies = get("/policies")
+    if policies["policies"] is None:
+        policies["policies"] = []
+    return policies
 
 
 def create_policy(policy):

--- a/schedule_scans.py
+++ b/schedule_scans.py
@@ -10,9 +10,12 @@ import nessus as ness_func
 @lru_cache(maxsize=1)
 def find_scan_policy(name="standard_scan"):
     """Find policy ID from policy Name"""
+    scan_policy = {}
     for policy in ness_func.list_policies()["policies"]:
         if policy["name"] == name:
-            return policy
+            scan_policy = policy
+            break
+    return scan_policy
 
 
 @lru_cache(maxsize=1)
@@ -27,10 +30,7 @@ def create_scan_policy(policy_file="scan_config/standard_scan_template.json"):
 
 def gds_scan_policy_id():
     """Find or Create the GDS scan policy and return it's ID"""
-    if ness_func.list_policies()["policies"]:
-        return find_scan_policy()["id"]
-    else:
-        return create_scan_policy()["policy_id"]
+    return find_scan_policy().get("id") or create_scan_policy()["policy_id"]
 
 
 @lru_cache(maxsize=1)

--- a/schedule_scans.py
+++ b/schedule_scans.py
@@ -27,7 +27,10 @@ def create_scan_policy(policy_file="scan_config/standard_scan_template.json"):
 
 def gds_scan_policy_id():
     """Find or Create the GDS scan policy and return it's ID"""
-    return find_scan_policy()["id"] or create_scan_policy()["policy_id"]
+    if ness_func.list_policies()["policies"]:
+        return find_scan_policy()["id"]
+    else:
+        return create_scan_policy()["policy_id"]
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
```
Scheduling scans...
Traceback (most recent call last):
  File "schedule_scans.py", line 161, in <module>
    main()
  File "schedule_scans.py", line 157, in main
    check_scan()
  File "schedule_scans.py", line 150, in check_scan
    create_all_scans(config, gds_scan_policy_id())
  File "schedule_scans.py", line 30, in gds_scan_policy_id
    return find_scan_policy()["id"] or create_scan_policy()["policy_id"]
  File "schedule_scans.py", line 13, in find_scan_policy
    for policy in ness_func.list_policies()["policies"]:
TypeError: 'NoneType' object is not iterable
```

This has been run locally and fixed the issue.