### PR TITLE
fix for ACM Terraform

### DIFF
--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -6,8 +6,9 @@ resource "aws_acm_certificate" "fqdn" {
 resource "aws_route53_record" "subdomain_validation" {
   for_each = {
     for domain_validation_option in aws_acm_certificate.fqdn.domain_validation_options : domain_validation_option.domain_name => {
-      name = domain_validation_option.resource_record_name
-      type = domain_validation_option.resource_record_type
+      name   = domain_validation_option.resource_record_name
+      record = domain_validation_option.resource_record_value
+      type   = domain_validation_option.resource_record_type
     }
   }
 

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -5,15 +5,15 @@ resource "aws_acm_certificate" "fqdn" {
 
 resource "aws_route53_record" "subdomain_validation" {
   for_each = {
-    for dvo in aws_acm_certificate.fqdn.domain_validation_options : dvo.domain_name => {
-      name = dvo.resource_record_name
-      type = dvo.resource_record_type
+    for domain_validation_option in aws_acm_certificate.fqdn.domain_validation_options : domain_validation_option.domain_name => {
+      name = domain_validation_option.resource_record_name
+      type = domain_validation_option.resource_record_type
     }
   }
 
   name    = each.value.name
   type    = each.value.type
-  records = each.value.record
+  records = [each.value.record]
   zone_id = data.aws_route53_zone.nessus_domain.id
   ttl     = 60
 }

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -4,22 +4,15 @@ resource "aws_acm_certificate" "fqdn" {
 }
 
 resource "aws_route53_record" "subdomain_validation" {
-  for_each = {
-    for domain_validation_option in aws_acm_certificate.fqdn.domain_validation_options : domain_validation_option.domain_name => {
-      name   = domain_validation_option.resource_record_name
-      record = domain_validation_option.resource_record_value
-      type   = domain_validation_option.resource_record_type
-    }
-  }
+  name    = aws_acm_certificate.fqdn.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.fqdn.domain_validation_options.0.resource_record_type
+  records = [aws_acm_certificate.fqdn.domain_validation_options.0.resource_record_value]
 
-  name    = each.value.name
-  type    = each.value.type
-  records = [each.value.record]
   zone_id = data.aws_route53_zone.nessus_domain.id
   ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "subdomain_wildcard" {
   certificate_arn         = aws_acm_certificate.fqdn.arn
-  validation_record_fqdns = [for record in aws_route53_record.subdomain_validation : record.fqdn]
+  validation_record_fqdns = [aws_route53_record.subdomain_validation.fqdn]
 }

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -44,7 +44,7 @@ resource "aws_instance" "nessus_instance" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = 30
+    volume_size = 38
   }
 
   tags = {

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,4 +1,4 @@
 provider "aws" {
-  region = var.region
+  region  = var.region
+  version = "2.68.0"
 }
-


### PR DESCRIPTION
PR to fix the following error which was returned the last time the pipeline ran after the TOML was updated -:

```
Error: Invalid index

  on acm.tf line 7, in resource "aws_route53_record" "subdomain_validation":
   7:   name    = aws_acm_certificate.fqdn.domain_validation_options.0.resource_record_name

This value does not have any indices.


Error: Invalid index

  on acm.tf line 8, in resource "aws_route53_record" "subdomain_validation":
   8:   type    = aws_acm_certificate.fqdn.domain_validation_options.0.resource_record_type

This value does not have any indices.


Error: Invalid index

  on acm.tf line 9, in resource "aws_route53_record" "subdomain_validation":
   9:   records = [aws_acm_certificate.fqdn.domain_validation_options.0.resource_record_value]

This value does not have any indices.
```