### PR TITLE
Add cron for yum update to cloudinit

### DIFF
--- a/terraform/cloudinit/nessus_instance.yml
+++ b/terraform/cloudinit/nessus_instance.yml
@@ -3,6 +3,17 @@ hostname: ${hostname}
 manage_etc_hosts: true
 package_upgrade: true
 locale: en_GB.UTF-8
+write_files:
+  - path: /usr/local/bin/yum-update
+    permissions: '0755'
+    content: |
+      #!/bin/sh
+      yum -y update
+  - path: /etc/crontab
+    content: |
+      0 7 * * * /usr/local/bin/yum-update
+    append: true
+
 runcmd:
   - |
     cat>/usr/local/bin/nessus-cloudinit.sh<<EOF


### PR DESCRIPTION
[Nessus still uses Amazon Linux 1](https://aws.amazon.com/marketplace/pp/Tenable-Inc-Nessus-BYOL/B01EHYYYRO) which means we are unable to update the kernel using the [live patching](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/al2-live-patching.html). 

I also noticed that Nessus rarely gets redeployed as there aren't many changes pushed to the repo. I thought it might be a good idea to create a cron in the cloudinit script that does an update with `yum -y update` every morning so we can keep it up to date. I ran an update manually just before I wrote this too. 